### PR TITLE
Bump up hyper-native-tls to 0.3 for compatibility with OpenSSL 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ yup-oauth2 = "1.0.7"
 
 # These versions required by google-drive3
 hyper = "0.10"
-hyper-native-tls = "0.2"
+hyper-native-tls = "0.3"


### PR DESCRIPTION
Was not able to compile it from the AUR or from this repo, as it had the error:

```
error: failed to run custom build command for `openssl v0.9.24`
process didn't exit successfully: `/build/rustup/src/rustup.rs-1.14.0/target/release/build/openssl-4e050bcc8f5aae18/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'Unable to detect OpenSSL version', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/build.rs:16:14
note: Run with `RUST_BACKTRACE=1` for a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed 
```

When I tried bumping up the version of hyper-native-tls, it seemed to build successfully!