### PR TITLE
fix umount in systemd unit

### DIFF
--- a/gcsf.service
+++ b/gcsf.service
@@ -16,7 +16,7 @@ Environment=RUST_BACKTRACE=1
 Environment=GCSF_MOUNTPOINT="/path/to/some/mount/point"
 Environment=GCSF_SESSION="some_session_name"
 ExecStart=/full/path/to/gcsf mount $GCSF_MOUNTPOINT -s $GCSF_SESSION
-ExecStop=fusermount -u $GCSF_MOUNTPOINT
+ExecStop=/bin/fusermount -u $GCSF_MOUNTPOINT
 User=some_user_name
 # GCSF will die by itself after the fusermount command
 KillMode=none


### PR DESCRIPTION
This fixes following:
```
Executable path is not absolute, ignoring: fusermount -u $GCSF_MOUNTPOINT
```