### PR TITLE
Allow custom Google OAuth client secrets

### DIFF
--- a/sample_config.toml
+++ b/sample_config.toml
@@ -51,3 +51,8 @@ rename_identical_files = false
 # If set to true, deleted files and folder will not be moved to Trash Folder,
 # instead they get deleted permanently.
 skip_trash = false
+
+
+# The Google OAuth client secret for Google Drive APIs. Create your own
+# credentials at https://console.developers.google.com and paste them here
+client_secret = """{"installed":{"client_id":"726003905312-e2mq9mesjc5llclmvc04ef1k7qopv9tu.apps.googleusercontent.com","project_id":"weighty-triode-199418","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://accounts.google.com/o/oauth2/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_secret":"hp83n1Rzz8UpxgCnqvX15qC2","redirect_uris":["urn:ietf:wg:oauth:2.0:oob","http://localhost"]}}"""

--- a/src/gcsf/config.rs
+++ b/src/gcsf/config.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub authorize_using_code: Option<bool>,
     pub rename_identical_files: Option<bool>,
     pub skip_trash: Option<bool>,
+    pub client_secret: Option<String>,
 }
 
 impl Config {
@@ -89,5 +90,11 @@ impl Config {
     /// If set to true, deleted files and folder will not be moved to Trash Folder, instead they get deleted permanently.
     pub fn skip_trash(&self) -> bool {
         self.skip_trash.unwrap_or(false)
+    }
+
+    /// The Google OAuth client secret for Google Drive APIs. Create your own
+    /// credentials at https://console.developers.google.com and paste them here
+    pub fn client_secret(&self) -> &String {
+        self.client_secret.as_ref().unwrap()
     }
 }

--- a/src/gcsf/drive_facade.rs
+++ b/src/gcsf/drive_facade.rs
@@ -14,8 +14,6 @@ use std::io;
 use std::io::{Read, Seek, SeekFrom};
 
 const PAGE_SIZE: i32 = 1000;
-const CLIENT_SECRET: &str = "{\"installed\":{\"client_id\":\"726003905312-e2mq9mesjc5llclmvc04ef1k7qopv9tu.apps.googleusercontent.com\",\"project_id\":\"weighty-triode-199418\",\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\",\"client_secret\":\"hp83n1Rzz8UpxgCnqvX15qC2\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"http://localhost\"]}}";
-
 type DriveId = String;
 
 type GCClient = hyper::Client;
@@ -91,7 +89,7 @@ impl DriveFacade {
     }
 
     fn create_drive_auth(config: &Config) -> Result<GCAuthenticator, Error> {
-        let secret: oauth2::ConsoleApplicationSecret = serde_json::from_str(CLIENT_SECRET)?;
+        let secret: oauth2::ConsoleApplicationSecret = serde_json::from_str(config.client_secret())?;
         let secret = secret
             .installed
             .ok_or(err_msg("ConsoleApplicationSecret.installed is None"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ const DEBUG_LOG: &str = "hyper::client=error,hyper::http=error,hyper::net=error,
 const INFO_LOG: &str =
     "hyper::client=error,hyper::http=error,hyper::net=error,fuse::session=error,info";
 
-const DEFAULT_CONFIG: &str = "\
+const DEFAULT_CONFIG: &str = r#"
 ### This is the configuration file that GCSF uses.
 ### It should be placed in $XDG_CONFIG_HOME/gcsf/gcsf.toml, which is usually
 ### defined as $HOME/.config/gcsf/gcsf.toml
@@ -63,12 +63,12 @@ sync_interval = 10
 
 # Mount options
 mount_options = [
-    \"fsname=GCSF\",
+    "fsname=GCSF",
     # Allow file system access to root. This only works if `user_allow_other`
     # is set in /etc/fuse.conf
-    \"allow_root\",
-    \"big_writes\",
-    \"max_write=131072\"
+    "allow_root",
+    "big_writes",
+    "max_write=131072"
 ]
 
 # If set to true, Google Drive will provide a code after logging in and
@@ -84,7 +84,12 @@ rename_identical_files = false
 
 # If set to true, deleted files will remove them permanently instead of moving them to Trash.
 # Deleting trashed files always removes them permanently.
-skip_trash = false\n";
+skip_trash = false
+
+# The Google OAuth client secret for Google Drive APIs. Create your own
+# credentials at https://console.developers.google.com and paste them here
+client_secret = """{"installed":{"client_id":"726003905312-e2mq9mesjc5llclmvc04ef1k7qopv9tu.apps.googleusercontent.com","project_id":"weighty-triode-199418","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://accounts.google.com/o/oauth2/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_secret":"hp83n1Rzz8UpxgCnqvX15qC2","redirect_uris":["urn:ietf:wg:oauth:2.0:oob","http://localhost"]}}"""
+"#;
 
 fn mount_gcsf(config: Config, mountpoint: &str) {
     let vals = config.mount_options();


### PR DESCRIPTION
# Summary
Allow users to specify their own client secrets to fix #75 and to avoid rate-limit issues with Google's APIs 

# Changes

- Add client_secret field to config
- Remove use of hard-coded CLIENT_SECRET
- Update config references to include client_secret